### PR TITLE
Ruby 2.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: ruby
 rvm:
+  - 2.3.6
   - 2.4.1
 
 env:

--- a/lib/phobos_prometheus/config_parser.rb
+++ b/lib/phobos_prometheus/config_parser.rb
@@ -136,7 +136,7 @@ module PhobosPrometheus
     def self.assert_array_of_type(metric, key, type)
       ary = metric[key.to_s]
       ary.is_a?(Array) && \
-        ary.all? { |value| value.class == type }
+        ary.all? { |value| value.is_a? type }
     end
 
     def self.fail_config(message)


### PR DESCRIPTION
We've stumbled upon `ConfigParser` not working on 2.3. It only takes a bunch of simple fixes to make it work. However I'm not sure if this project wants to support "older" rubies. WDYT?